### PR TITLE
Support for downloading Steam metadata in other languages

### DIFF
--- a/source/UniversalSteamMetadata.Tests/MetadataTest.cs
+++ b/source/UniversalSteamMetadata.Tests/MetadataTest.cs
@@ -15,7 +15,8 @@ namespace UniversalSteamMetadata.Tests
         public void StandardDownloadTest()
         {
             var provider = new MetadataProvider(new SteamApiClient());
-            var data = provider.GetGameMetadata(578080, BackgroundSource.Image, true);
+            var data = provider.GetGameMetadata(578080,
+                new UniversalSteamMetadataSettings{BackgroundSource = BackgroundSource.Image, DownloadVerticalCovers = true});
             Assert.IsNotNull(data.GameInfo);
             Assert.IsNotNull(data.Icon);
             Assert.IsNotNull(data.CoverImage);
@@ -34,7 +35,8 @@ namespace UniversalSteamMetadata.Tests
         public void VRMetadataTest()
         {
             var provider = new MetadataProvider(new SteamApiClient());
-            var data = provider.GetGameMetadata(378860, BackgroundSource.Banner, true);
+            var data = provider.GetGameMetadata(378860,
+                new UniversalSteamMetadataSettings { BackgroundSource = BackgroundSource.Banner, DownloadVerticalCovers = true });
             Assert.IsTrue(data.GameInfo.Features.Contains("VR"));
         }
     }

--- a/source/UniversalSteamMetadata/SteamShared/WebApiClient.cs
+++ b/source/UniversalSteamMetadata/SteamShared/WebApiClient.cs
@@ -18,9 +18,9 @@ namespace Steam
             return JsonConvert.DeserializeObject<AppReviewsResult>(HttpDownloader.DownloadString(url));
         }
 
-        public static StoreAppDetailsResult.AppDetails GetStoreAppDetail(uint appId)
+        public static StoreAppDetailsResult.AppDetails GetStoreAppDetail(uint appId, SteamLanguage language = SteamLanguage.english)
         {
-            var url = $"https://store.steampowered.com/api/appdetails?appids={appId}&l=english";
+            var url = $"https://store.steampowered.com/api/appdetails?appids={appId}&l={language:G}";
             var parsedData = JsonConvert.DeserializeObject<Dictionary<string, StoreAppDetailsResult>>(HttpDownloader.DownloadString(url));
             var response = parsedData[appId.ToString()];
 

--- a/source/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
+++ b/source/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
@@ -247,10 +247,7 @@ namespace UniversalSteamMetadata
                 if (BuiltinExtensions.GetExtensionFromId(options.GameData.PluginId) == BuiltinExtension.SteamLibrary)
                 {
                     var appId = uint.Parse(options.GameData.GameId);
-                    currentMetadata = metadataProvider.GetGameMetadata(
-                        appId,
-                        plugin.Settings.BackgroundSource,
-                        plugin.Settings.DownloadVerticalCovers);
+                    currentMetadata = metadataProvider.GetGameMetadata(appId, plugin.Settings);
                 }
                 else
                 {
@@ -259,10 +256,7 @@ namespace UniversalSteamMetadata
                         var matchedId = GetMatchingGame(options.GameData);
                         if (matchedId > 0)
                         {
-                            currentMetadata = metadataProvider.GetGameMetadata(
-                                matchedId,
-                                plugin.Settings.BackgroundSource,
-                                plugin.Settings.DownloadVerticalCovers);
+                            currentMetadata = metadataProvider.GetGameMetadata(matchedId, plugin.Settings);
                         }
                         else
                         {
@@ -311,10 +305,8 @@ namespace UniversalSteamMetadata
                         }
                         else
                         {
-                            currentMetadata = metadataProvider.GetGameMetadata(
-                                ((StoreSearchResult)selectedGame).GameId,
-                                plugin.Settings.BackgroundSource,
-                                plugin.Settings.DownloadVerticalCovers);
+                            currentMetadata =
+                                metadataProvider.GetGameMetadata(((StoreSearchResult) selectedGame).GameId, plugin.Settings);
                         }
                     }
                 }

--- a/source/UniversalSteamMetadata/UniversalSteamMetadataSettings.cs
+++ b/source/UniversalSteamMetadata/UniversalSteamMetadataSettings.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace UniversalSteamMetadata
 {
-    public class UniversalSteamMetadataSettings : ISettings
+    public class UniversalSteamMetadataSettings : ISettings, ISteamMetadataDownloadConfig
     {
         private readonly UniversalSteamMetadata plugin;
         private UniversalSteamMetadataSettings editingClone;
@@ -17,6 +17,10 @@ namespace UniversalSteamMetadata
         public bool DownloadVerticalCovers { get; set; } = true;
 
         public BackgroundSource BackgroundSource { get; set; } = BackgroundSource.Image;
+
+        public SteamLanguage MetadataDescriptionLanguage { get; set; } = SteamLanguage.english;
+
+        public SteamLanguage MetadataOtherLanguage { get; set; } = SteamLanguage.english;
 
         public UniversalSteamMetadataSettings()
         {
@@ -31,6 +35,8 @@ namespace UniversalSteamMetadata
             {
                 DownloadVerticalCovers = savedSettings.DownloadVerticalCovers;
                 BackgroundSource = savedSettings.BackgroundSource;
+                MetadataDescriptionLanguage = savedSettings.MetadataDescriptionLanguage;
+                MetadataOtherLanguage = savedSettings.MetadataOtherLanguage;
             }
         }
 

--- a/source/UniversalSteamMetadata/UniversalSteamMetadataSettingsView.xaml
+++ b/source/UniversalSteamMetadata/UniversalSteamMetadataSettingsView.xaml
@@ -15,6 +15,12 @@
                 <x:Type TypeName="steam:BackgroundSource" />
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}"
+                            x:Key="SteamLanguageEnumValues">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="steam:SteamLanguage" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
     </UserControl.Resources>
 
     <StackPanel Margin="20">
@@ -27,5 +33,19 @@
                   Width="150" HorizontalAlignment="Left"
                   SelectedValue="{Binding BackgroundSource}"
                   ItemsSource="{Binding Source={StaticResource BackgroundSourceEnumValues}}" />
+
+        <TextBlock Text="Preferred game description language:" VerticalAlignment="Center" Margin="0,10,0,10" />
+
+        <ComboBox Margin="0,0,0,10"
+                  Width="150" HorizontalAlignment="Left"
+                  SelectedValue="{Binding MetadataDescriptionLanguage}"
+                  ItemsSource="{Binding Source={StaticResource SteamLanguageEnumValues}}" />
+
+        <TextBlock Text="Preferred general metadata language:" VerticalAlignment="Center" Margin="0,10,0,10" />
+
+        <ComboBox Margin="0,0,0,10"
+                  Width="150" HorizontalAlignment="Left"
+                  SelectedValue="{Binding MetadataOtherLanguage}"
+                  ItemsSource="{Binding Source={StaticResource SteamLanguageEnumValues}}" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
I'll leave this here in case you are interested in these changes. It addresses issue #4 .

I added two settings with which you can select the preferred language for:
1. game description
2. other metadata

Both settings default to English. 
If you only change setting 1, the plugin downloads localized game descriptions but keeps everything else (genre, features, etc.) in English, which can be useful to maintain compatibility with other metadata sources (if needed).

To avoid code duplication I also made a change that all the different plugin settings are now passed via an interface object parameter (the settings class implements the interface) to the MetadataProvider, instead of as individual arguments.